### PR TITLE
Treat missing cache buster as valid

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ about how assets are generated and opinions about how they should be served:
   Python package. Typically Hypothesis applications use a `build` directory in
   the root of the repository.
 - Cache busting is always enabled and is done via query strings. These query
-  strings are checked when serving a request to avoid responses being stored
-  under the wrong keys in downstream caches.
+  strings are checked, if present, when serving a request to avoid responses
+  being stored under the wrong keys in downstream caches.
 - It is assumed that compressing bytes (eg. with gzip or Brotli) will be
   handled by a service like Cloudflare, not the Python application.
 

--- a/src/h_assets/view.py
+++ b/src/h_assets/view.py
@@ -12,7 +12,10 @@ def assets_view(environment: Environment):
     static = static_view(environment.asset_root(), cache_max_age=None, use_subpath=True)
 
     def wrapper(context, request):
-        if not environment.check_cache_buster(request.path, request.query_string):
+        # If a cache-busting query string is provided, verify that it is correct.
+        if request.query_string and not environment.check_cache_buster(
+            request.path, request.query_string
+        ):
             return HTTPNotFound()
 
         return static(context, request)

--- a/tests/unit/h_assets/view_test.py
+++ b/tests/unit/h_assets/view_test.py
@@ -26,10 +26,26 @@ class TestAssetsView:
         static_view.return_value.assert_called_with(sentinel.context, request)
         assert response == static_view.return_value.return_value
 
+    def test_it_returns_static_view_response_if_cache_buster_missing(
+        self, static_view, environment
+    ):
+        request = DummyRequest(query_string="")
+        request.path = "/path"
+
+        response = assets_view(environment)(sentinel.context, request)
+
+        environment.check_cache_buster.assert_not_called()
+
+        static_view.assert_called_once_with(
+            environment.asset_root.return_value, cache_max_age=None, use_subpath=True
+        )
+        static_view.return_value.assert_called_with(sentinel.context, request)
+        assert response == static_view.return_value.return_value
+
     def test_it_returns_404_if_cache_buster_invalid(self, environment, static_view):
         environment.check_cache_buster.return_value = False
 
-        response = assets_view(environment)({}, DummyRequest())
+        response = assets_view(environment)({}, DummyRequest(query_string="invalid"))
 
         static_view.return_value.assert_not_called()
         assert isinstance(response, HTTPNotFound)


### PR DESCRIPTION
When deploying the first release of h-assets in h we found a handful of non-critical cases where asset URLs were being generated without cache busters:

 - An icon font URL in a CSS file
 - Source map URLs in generated JS bundles (I really should have noticed this earlier)

To make the initial deployment of h-assets easier, this commit relaxes the cache-buster check to always allow requests if there is no cache-busting query string. We can increase the strictness in a later release once all the downstream projects are ready.

---

To test this change with the h or lms projects:

1. Build a local wheel from this branch using `make dist` and change `requirements.txt` in h/lms to reference it
2. Go to some page in h and grab and asset URL from one of the `<script>` or `<style>` tags in the page
3. Using curl try fetching the URL with the query string, without the query string (should both succeed) and with a different query string (should return a 404)