### PR TITLE
Set `Cache-Control: no-cache` if cache buster check fails

### DIFF
--- a/src/h_assets/view.py
+++ b/src/h_assets/view.py
@@ -16,7 +16,14 @@ def assets_view(environment: Environment):
         if request.query_string and not environment.check_cache_buster(
             request.path, request.query_string
         ):
-            return HTTPNotFound()
+            response = HTTPNotFound()
+
+            # Disable downstream caching of failed responses, in case this
+            # happened due to version skew during a deployment. See
+            # https://github.com/hypothesis/h-assets/issues/27.
+            response.cache_control.no_cache = True
+
+            return response
 
         return static(context, request)
 

--- a/tests/unit/h_assets/view_test.py
+++ b/tests/unit/h_assets/view_test.py
@@ -50,6 +50,9 @@ class TestAssetsView:
         static_view.return_value.assert_not_called()
         assert isinstance(response, HTTPNotFound)
 
+        # Returns "*" though set to `True`
+        assert response.cache_control.no_cache  # pylint: disable=no-member
+
     @pytest.fixture
     def environment(self):
         return create_autospec(Environment, instance=True, spec_set=True)


### PR DESCRIPTION
If an asset URL fetch fails due to version skew across multiple servers in a deployment, prevent the 4xx response from being cached by the CDN or browser.

The proper solution is for the downstream app to either deploy assets ahead of the app deployment, or use sticky sessions. This change reduces the downside if eg. stickiness fails for any reason.

Fixes https://github.com/hypothesis/h-assets/issues/27

---

**Testing:**

1. Check out this branch and install the local h-assets package in h (`tox -e dev --run-command "pip install -e /path/to/h-assets"`)
2. Get a valid asset URL, including the query string, from the HTML of `http://localhost:5000/search`
3. Fetch that URL. It should return a 200 response with no `Cache-Control` header
4. Change the query param to be different and fetch again. It should return a 404 response with the `Cache-Control: no-cache` header set