### PR TITLE
Add Environment method to generate an import map

### DIFF
--- a/src/h_assets/environment.py
+++ b/src/h_assets/environment.py
@@ -68,6 +68,32 @@ class Environment:
 
         return f"{self.assets_base_url}/{self.manifest_file.load()[path]}"
 
+    def import_map(self):
+        """
+        Return JSON-serializable content for an import map.
+
+        An import map can be used to configure how module specifiers in
+        JS `import` statements and `import()` expressions are mapped to URLs.
+        By rendering an import map into the HTML of the page, dynamic imports
+        in module scripts will be mapped from their original URLs to the
+        cache-busted versions.
+
+        The use of import maps is especially important if a bundle might be
+        be referenced in both server-rendered HTML via `<script>` tags and
+        dynamic imports. In that case all references need to use the same URL
+        to ensure that the module is only instantiated once.
+
+        See https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap.
+        """
+        base_url = self.assets_base_url
+        imports = {
+            f"{base_url}/{path}": f"{base_url}/{cache_busted_path}"
+            for path, cache_busted_path in self.manifest_file.load().items()
+            # Import maps are currently only used by scripts.
+            if path.endswith(".js")
+        }
+        return {"imports": imports}
+
     def check_cache_buster(self, path, query):
         """
         Check if the cache buster in an asset request URL matches the manifest.

--- a/tests/unit/h_assets/environment_test.py
+++ b/tests/unit/h_assets/environment_test.py
@@ -62,6 +62,14 @@ class TestEnvironment:
             "/assets/vendor.bundle.js?hash_vendor",
         ]
 
+    def test_import_map(self, environment):
+        assert environment.import_map() == {
+            "imports": {
+                "/assets/app.bundle.js": "/assets/app.bundle.js?hash_app",
+                "/assets/vendor.bundle.js": "/assets/vendor.bundle.js?hash_vendor",
+            }
+        }
+
     @pytest.fixture
     def environment(self):
         return Environment(
@@ -95,6 +103,7 @@ class TestEnvironment:
         CachedJSONFile.return_value.load.return_value = {
             "app.bundle.js": "app.bundle.js?hash_app",
             "vendor.bundle.js": "vendor.bundle.js?hash_vendor",
+            "app.css": "app.css?hash_app_css",
         }
 
         return CachedJSONFile


### PR DESCRIPTION
In order to enable on-demand loading of JS modules from our app, add an `Environment.import_map` method which returns the JSON content for a `<script type="importmap">` tag.

By rendering such a tag onto a page, an application can ensure that `import('scripts/some-module.bundle.js')` in a bundle is resolved to the same cache-busted URL as when a `<script>` tag is generated as part of rendering the page's HTML.

See https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap for more details on import map usage.

Usage in a Python application will look like:

```py
def _configure_jinja2_assets(config):
    assets_env = config.registry["assets_env"]

    jinja2_env = config.get_jinja2_environment()
    jinja2_env.globals["asset_url"] = assets_env.url
    jinja2_env.globals["asset_urls"] = assets_env.urls
    jinja2_env.globals["asset_import_map"] = assets_env.import_map
```

Then in a Jinja template:

```jinja2
{% block importmap %}
<script type="importmap">{{ asset_import_map() | tojson }}</script>
{% endblock %}
```

Part of https://github.com/hypothesis/h/issues/9709.